### PR TITLE
Add Deprecation Warning and Suggested Replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This repository contains a simple `ILoggerProvider` implementation which sends all log messages to [Log4Net][log4net].
 
+## ⚠️ Deprecation Warning ⚠️
+
+This project is no longer maintained. It is suggested that you use [Microsoft.Extensions.Logging.Log4Net.AspNetCore](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Log4Net.AspNetCore) instead.
+
 ## Getting Started
 
 This logging provider can be used from anywhere which supports .NET Standard 2.0 or above. To get started just install the NuGet package:

--- a/src/Jmw.Log4NetProvider/Jmw.Log4NetProvider.csproj
+++ b/src/Jmw.Log4NetProvider/Jmw.Log4NetProvider.csproj
@@ -4,7 +4,7 @@
     <Description>This project is no longer maintained. It is suggested you use Microsoft.Extensions.Logging.Log4Net.AspNetCore (https://www.nuget.org/packages/Microsoft.Extensions.Logging.Log4Net.AspNetCore/) instead.
 	Log4Net provider for Net.Core logging system.</Description>
     <AssemblyTitle>Log4NetProvider</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <Authors>Jean-Marc Weeger,Will Speak</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>

--- a/src/Jmw.Log4NetProvider/Jmw.Log4NetProvider.csproj
+++ b/src/Jmw.Log4NetProvider/Jmw.Log4NetProvider.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Log4Net provider for Net.Core logging system</Description>
+    <Description>This project is no longer maintained. It is suggested you use Microsoft.Extensions.Logging.Log4Net.AspNetCore (https://www.nuget.org/packages/Microsoft.Extensions.Logging.Log4Net.AspNetCore/) instead.
+	Log4Net provider for Net.Core logging system.</Description>
     <AssemblyTitle>Log4NetProvider</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Jean-Marc Weeger,Will Speak</Authors>


### PR DESCRIPTION
Add deprecation warnings to the README and package. 

Update the README and package description to suggest an alternative
logging provider. Microsoft.Extensions.Logging.Log4net.AspNetCore is a
more maintained package these days and supports the ASP .NET Core 2.0
style logging registration too.